### PR TITLE
failover to python-magic detection if vendored library not present

### DIFF
--- a/tests/test_libmagic_load.py
+++ b/tests/test_libmagic_load.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) nexB Inc. and others.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Visit https://aboutcode.org and https://github.com/nexB/ for support and download.
+# ScanCode is a trademark of nexB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+from typecode.magic2 import libmagic_version
+
+
+def test_load_lib():
+    assert libmagic_version > 0


### PR DESCRIPTION
This allows scancode to work on platforms not supported by typecode-libmagic
e.g. M1 Macs or windows WSL

100% tests pass with this change on my M1 Mac