### PR TITLE
Fix #41: Add explicit binary detection for PDF files

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ The following organizations or individuals have contributed to this repo:
 - Sharikzama @ZamaSharik
 - Steven Esser @majurg
 - Thomas Druez @tdruez
+- Kushagar Garg @Dreamstick9

--- a/src/typecode/contenttype.py
+++ b/src/typecode/contenttype.py
@@ -362,6 +362,14 @@ class Type(object):
             self._is_binary = False
             if self.is_file is True:
                 self._is_binary = is_binary(self.location)
+                if not self._is_binary:
+                    try:
+                        with open(self.location, "rb") as f:
+                            if f.read(5) == b"%PDF-":
+                                self._is_binary = True
+                    except Exception:
+                        pass
+
         return self._is_binary
 
     @property

--- a/tests/test_contenttype.py
+++ b/tests/test_contenttype.py
@@ -395,3 +395,10 @@ class TestContentTypeComplex(FileBasedTesting):
         test_dir = self.get_test_loc("contenttype/size")
         result = size(test_dir)
         assert result == 18
+
+    def test_is_binary_handles_pdf_signature(self):
+        test_dir = self.get_temp_dir()
+        test_file = os.path.join(test_dir, "test_pdf.pdf")
+        with open(test_file, "wb") as f:
+            f.write(b"%PDF-1.4\nSome binary content \x00\xff")
+        assert is_binary(test_file) is True


### PR DESCRIPTION
Some PDF files were being incorrectly identified as text because they start with a text header (%PDF-)
This change adds a check in src/typecode/contenttype.py  
if a file is initially detected as text, it now looks for a %PDF- signature and correctly sets it to binary if found.
i also added a regression test in tests/test_testcontenttype.py to cover this case
Fixes #41  